### PR TITLE
chore: remove postmanlabs references in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,10 +8,9 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:postmanlabs/postject.git"
+    "url": "git@github.com:nodejs/postject.git"
   },
-  "homepage": "https://github.com/postmanlabs/postject#readme",
-  "author": "Postman Labs <help@postman.com> (=)",
+  "homepage": "https://github.com/nodejs/postject#readme",
   "bin": {
     "postject": "./dist/cli.js"
   },


### PR DESCRIPTION
This commit replaces the package.json references
to postmanlabs with nodejs to reflect reality and
because the npm page displays these.