### PR TITLE
chore: add `patches/` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,4 +10,5 @@ scripts/
 src/
 test/
 vendor/
+patches/
 !dist/postject-api.h


### PR DESCRIPTION
There's no reason to make https://github.com/nodejs/postject/tree/main/patches/ a part of the release.