### PR TITLE
feat: make postject faster

### DIFF
--- a/src/postject.cpp
+++ b/src/postject.cpp
@@ -14,10 +14,12 @@ enum class ExecutableFormat { kELF, kMachO, kPE, kUnknown };
 enum class InjectResult { kAlreadyExists, kError, kSuccess };
 
 std::vector<uint8_t> vec_from_val(const emscripten::val& value) {
-  // TODO(dsanders11) - vecFromJSArray incurs a copy, so memory usage is higher
-  //                    than it needs to be. Explore ways to access the memory
-  //                    directly and avoid the copy.
-  return emscripten::vecFromJSArray<uint8_t>(value);
+  // We are using `convertJSArrayToNumberVector()` instead of `vecFromJSArray()`
+  // because it is faster. It is okay if we use it without additional type
+  // checking because this function is only called on Node.js Buffer instances
+  // which is expected to contain elements that are safe to pass to the JS
+  // function, `Number()`.
+  return emscripten::convertJSArrayToNumberVector<uint8_t>(value);
 }
 
 ExecutableFormat get_executable_format(const emscripten::val& executable) {

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -115,7 +115,7 @@ describe("postject CLI", () => {
       expect(status).to.equal(0);
       expect(stdout).to.have.string(resourceContents);
     }
-  }).timeout(3_00_000);
+  }).timeout(10_000);
 
   it("should display an error message when filename doesn't exist", async () => {
     {
@@ -137,7 +137,7 @@ describe("postject CLI", () => {
       expect(stdout).to.not.have.string("Injection done!");
       expect(status).to.equal(1);
     }
-  }).timeout(3_00_000);
+  }).timeout(10_000);
 
   it("should display an error message when the file is not a supported executable type", async () => {
     const bogusFile = path.join(tempDir, "bogus.exe");
@@ -160,7 +160,7 @@ describe("postject CLI", () => {
     );
     expect(stdout).to.not.have.string("Injection done!");
     expect(status).to.equal(1);
-  }).timeout(3_00_000);
+  }).timeout(10_000);
 });
 
 describe("postject API", () => {
@@ -234,7 +234,7 @@ describe("postject API", () => {
       expect(status).to.equal(0);
       expect(stdout).to.have.string(resourceContents);
     }
-  }).timeout(3_00_000);
+  }).timeout(10_000);
 });
 
 describe("api.js should not contain __filename and __dirname", () => {

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -115,7 +115,7 @@ describe("postject CLI", () => {
       expect(status).to.equal(0);
       expect(stdout).to.have.string(resourceContents);
     }
-  }).timeout(10_000);
+  }).timeout(15_000);
 
   it("should display an error message when filename doesn't exist", async () => {
     {
@@ -137,7 +137,7 @@ describe("postject CLI", () => {
       expect(stdout).to.not.have.string("Injection done!");
       expect(status).to.equal(1);
     }
-  }).timeout(10_000);
+  }).timeout(15_000);
 
   it("should display an error message when the file is not a supported executable type", async () => {
     const bogusFile = path.join(tempDir, "bogus.exe");
@@ -160,7 +160,7 @@ describe("postject CLI", () => {
     );
     expect(stdout).to.not.have.string("Injection done!");
     expect(status).to.equal(1);
-  }).timeout(10_000);
+  }).timeout(15_000);
 });
 
 describe("postject API", () => {
@@ -234,7 +234,7 @@ describe("postject API", () => {
       expect(status).to.equal(0);
       expect(stdout).to.have.string(resourceContents);
     }
-  }).timeout(10_000);
+  }).timeout(15_000);
 });
 
 describe("api.js should not contain __filename and __dirname", () => {


### PR DESCRIPTION
This change replaces the [`vecFromJSArray()`](https://emscripten.org/docs/api_reference/val.h.html?highlight=vecfromjsarray#_CPPv4N10emscripten10emscripten3val14vecFromJSArrayERK3val) call in `vec_from_val()` with a call to [`convertJSArrayToNumberVector()`](https://emscripten.org/docs/api_reference/val.h.html?highlight=convertjsarraytonumbervector#_CPPv4N10emscripten10emscripten3val28convertJSArrayToNumberVectorERK3val), which reduces the time consumption of Postject from ~30s to ~6s on a Mach-O Node.js binary when run on my x86_64 macOS.

Fixes: https://github.com/nodejs/postject/issues/85
Refs: https://github.com/emscripten-core/emscripten/pull/11119
CI: https://app.circleci.com/pipelines/github/RaisinTen/postject/8/workflows/6ac6bd04-5249-4c36-8daa-f86e8a52d7db