### PR TITLE
fix: print full error and cause with flag --verbose

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -16,8 +16,8 @@ async function inject(filename, resourceName, resourceData, options) {
 
   try {
     await fs.access(filename, constants.R_OK | constants.W_OK);
-  } catch {
-    throw new Error("Can't read and write to target executable");
+  } catch (cause) {
+    throw new Error("Can't read and write to target executable", { cause });
   }
 
   let executable;
@@ -26,8 +26,8 @@ async function inject(filename, resourceName, resourceData, options) {
 
   try {
     executable = await fs.readFile(filename);
-  } catch {
-    throw new Error("Couldn't read target executable");
+  } catch (cause) {
+    throw new Error("Couldn't read target executable", { cause });
   }
   const executableFormat = postject.getExecutableFormat(executable);
 
@@ -155,8 +155,8 @@ async function inject(filename, resourceName, resourceData, options) {
 
   try {
     await fs.writeFile(filename, buffer);
-  } catch {
-    throw new Error("Couldn't write executable");
+  } catch (cause) {
+    throw new Error("Couldn't write executable", { cause });
   }
 }
 

--- a/test/cli.mjs
+++ b/test/cli.mjs
@@ -123,6 +123,7 @@ describe("postject CLI", () => {
         "node",
         [
           "./dist/cli.js",
+          "--verbose",
           "unknown-filename",
           "foobar",
           resourceFilename,
@@ -133,6 +134,9 @@ describe("postject CLI", () => {
       );
       expect(stdout).to.have.string(
         "Error: Can't read and write to target executable"
+      );
+      expect(stdout).to.have.string(
+        "Error: ENOENT: no such file or directory"
       );
       expect(stdout).to.not.have.string("Injection done!");
       expect(status).to.equal(1);


### PR DESCRIPTION
Print full error information with flag `--verbose`. This could be helpful when debugging unknown errors, like when the target file is being locked (in use) on Windows.